### PR TITLE
New selection handler

### DIFF
--- a/StaticTableView/StaticCell.swift
+++ b/StaticTableView/StaticCell.swift
@@ -19,62 +19,62 @@ public class StaticCell: UITableViewCell {
         case push(UIViewController)
     }
     
-    public var selectionHandler: SelectionHandler?
+    public var whenSelected: SelectionHandler?
     public var configure: StaticCellConfigurationBlock
     
     public static let systemColor = UIColor(red: 0, green: 122/255, blue: 1, alpha: 1.0)
 
     
-    public init(style: UITableViewCell.CellStyle = .default, selectionHandler: SelectionHandler? = nil, configure: @escaping StaticCellConfigurationBlock) {
-        self.selectionHandler = selectionHandler
+    public init(style: UITableViewCell.CellStyle = .default, whenSelected: SelectionHandler? = nil, configure: @escaping StaticCellConfigurationBlock) {
+        self.whenSelected = whenSelected
         self.configure = configure
         super.init(style: style, reuseIdentifier: nil)
         self.selectionStyle = .none
     }
     
     ///Initializes a simple StaticCell with a text label and an optional accessory view.
-    public convenience init(text: String, accessoryView: UIView? = nil, selectionHandler: SelectionHandler? = nil) {
-        self.init(style: .default, selectionHandler: selectionHandler) {
+    public convenience init(text: String, accessoryView: UIView? = nil, whenSelected: SelectionHandler? = nil) {
+        self.init(style: .default, whenSelected: whenSelected) {
             $0.textLabel?.text = text
             $0.accessoryView = accessoryView
         }
     }
     
     ///Initializes a simple StaticCell with a text label and an accessory type.
-    public convenience init(text: String, accessoryType: UITableViewCell.AccessoryType, selectionHandler: SelectionHandler? = nil) {
-        self.init(style: .default, selectionHandler: selectionHandler) {
+    public convenience init(text: String, accessoryType: UITableViewCell.AccessoryType, whenSelected: SelectionHandler? = nil) {
+        self.init(style: .default, whenSelected: whenSelected) {
             $0.textLabel?.text = text
             $0.accessoryType = accessoryType
         }
     }
     
     ///Initializes a simple StaticCell with "button-style label".
-    public convenience init(buttonTitle: String, buttonColor: UIColor = systemColor, selectionHandler: SelectionHandler? = nil) {
-        self.init(style: .default, selectionHandler: selectionHandler) {
+    public convenience init(buttonTitle: String, buttonColor: UIColor = systemColor, whenSelected: SelectionHandler? = nil) {
+        self.init(style: .default, whenSelected: whenSelected) {
             $0.textLabel?.text = buttonTitle
             $0.textLabel?.textColor = buttonColor
         }
     }
     
     ///Initializes a simple StaticCell with a subtitle style.
-    public convenience init(title: String, subtitle: String, selectionHandler: SelectionHandler? = nil) {
-        self.init(style: .subtitle, selectionHandler: selectionHandler) {
+    public convenience init(title: String, subtitle: String, whenSelected: SelectionHandler? = nil) {
+        self.init(style: .subtitle, whenSelected: whenSelected) {
             $0.textLabel?.text = title
             $0.detailTextLabel?.text = subtitle
         }
     }
     
     ///Initializes a StaticCell with a value1 style.
-    public convenience init(leftText: String, rightText: String, selectionHandler: SelectionHandler? = nil) {
-        self.init(style: .value1, selectionHandler: selectionHandler) {
+    public convenience init(leftText: String, rightText: String, whenSelected: SelectionHandler? = nil) {
+        self.init(style: .value1, whenSelected: whenSelected) {
             $0.textLabel?.text = leftText
             $0.detailTextLabel?.text = rightText
         }
     }
     
     //Initializes a StaticCell that displays a text and a static UISwitch control.
-    public convenience init(text: String, switchOn: Bool, selectionHandler: SelectionHandler? = nil) {
-        self.init(style: .default, selectionHandler: selectionHandler) {
+    public convenience init(text: String, switchOn: Bool, whenSelected: SelectionHandler? = nil) {
+        self.init(style: .default, whenSelected: whenSelected) {
             $0.textLabel?.text = text
             
             let control = UISwitch()

--- a/StaticTableView/StaticCell.swift
+++ b/StaticTableView/StaticCell.swift
@@ -12,62 +12,69 @@ public class StaticCell: UITableViewCell {
     public typealias StaticCellSelectionBlock = (StaticCell, StaticTableViewController) -> ()
     public typealias StaticCellConfigurationBlock = (StaticCell) -> ()
     
-    public var didSelect: StaticCellSelectionBlock?
+    public enum SelectionHandler {
+        case execute(StaticCellSelectionBlock)
+        case open(URL)
+        case present(UIViewController)
+        case push(UIViewController)
+    }
+    
+    public var selectionHandler: SelectionHandler?
     public var configure: StaticCellConfigurationBlock
     
     public static let systemColor = UIColor(red: 0, green: 122/255, blue: 1, alpha: 1.0)
 
     
-    public init(style: UITableViewCell.CellStyle = .default, didSelect: StaticCellSelectionBlock? = nil, configure: @escaping StaticCellConfigurationBlock) {
-        self.didSelect = didSelect
+    public init(style: UITableViewCell.CellStyle = .default, selectionHandler: SelectionHandler? = nil, configure: @escaping StaticCellConfigurationBlock) {
+        self.selectionHandler = selectionHandler
         self.configure = configure
         super.init(style: style, reuseIdentifier: nil)
         self.selectionStyle = .none
     }
     
     ///Initializes a simple StaticCell with a text label and an optional accessory view.
-    public convenience init(text: String, accessoryView: UIView? = nil, whenSelected: StaticCellSelectionBlock? = nil) {
-        self.init(style: .default, didSelect: whenSelected) {
+    public convenience init(text: String, accessoryView: UIView? = nil, selectionHandler: SelectionHandler? = nil) {
+        self.init(style: .default, selectionHandler: selectionHandler) {
             $0.textLabel?.text = text
             $0.accessoryView = accessoryView
         }
     }
     
     ///Initializes a simple StaticCell with a text label and an accessory type.
-    public convenience init(text: String, accessoryType: UITableViewCell.AccessoryType, whenSelected: StaticCellSelectionBlock? = nil) {
-        self.init(style: .default, didSelect: whenSelected) {
+    public convenience init(text: String, accessoryType: UITableViewCell.AccessoryType, selectionHandler: SelectionHandler? = nil) {
+        self.init(style: .default, selectionHandler: selectionHandler) {
             $0.textLabel?.text = text
             $0.accessoryType = accessoryType
         }
     }
     
     ///Initializes a simple StaticCell with "button-style label".
-    public convenience init(buttonTitle: String, buttonColor: UIColor = systemColor, whenSelected: StaticCellSelectionBlock? = nil) {
-        self.init(style: .default, didSelect: whenSelected) {
+    public convenience init(buttonTitle: String, buttonColor: UIColor = systemColor, selectionHandler: SelectionHandler? = nil) {
+        self.init(style: .default, selectionHandler: selectionHandler) {
             $0.textLabel?.text = buttonTitle
             $0.textLabel?.textColor = buttonColor
         }
     }
     
     ///Initializes a simple StaticCell with a subtitle style.
-    public convenience init(title: String, subtitle: String, whenSelected: StaticCellSelectionBlock? = nil) {
-        self.init(style: .subtitle, didSelect: whenSelected) {
+    public convenience init(title: String, subtitle: String, selectionHandler: SelectionHandler? = nil) {
+        self.init(style: .subtitle, selectionHandler: selectionHandler) {
             $0.textLabel?.text = title
             $0.detailTextLabel?.text = subtitle
         }
     }
     
     ///Initializes a StaticCell with a value1 style.
-    public convenience init(leftText: String, rightText: String, whenSelected: StaticCellSelectionBlock? = nil) {
-        self.init(style: .value1, didSelect: whenSelected) {
+    public convenience init(leftText: String, rightText: String, selectionHandler: SelectionHandler? = nil) {
+        self.init(style: .value1, selectionHandler: selectionHandler) {
             $0.textLabel?.text = leftText
             $0.detailTextLabel?.text = rightText
         }
     }
     
     //Initializes a StaticCell that displays a text and a static UISwitch control.
-    public convenience init(text: String, switchOn: Bool, whenSelected: StaticCellSelectionBlock? = nil) {
-        self.init(style: .default, didSelect: whenSelected) {
+    public convenience init(text: String, switchOn: Bool, selectionHandler: SelectionHandler? = nil) {
+        self.init(style: .default, selectionHandler: selectionHandler) {
             $0.textLabel?.text = text
             
             let control = UISwitch()

--- a/StaticTableView/StaticTableView.swift
+++ b/StaticTableView/StaticTableView.swift
@@ -59,7 +59,7 @@ public class StaticTableViewController: UITableViewController {
     override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         ///As a context, we pass the cell itself and the tableViewController (useful for navigation purposes)
         let cell = self.cell(for: indexPath)
-        guard let handler = cell.selectionHandler else { return }
+        guard let handler = cell.whenSelected else { return }
         
         switch handler {
         case let .execute(block):

--- a/StaticTableView/StaticTableView.swift
+++ b/StaticTableView/StaticTableView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SafariServices
 
 ///A TableViewController that displays static cells.
 public class StaticTableViewController: UITableViewController {
@@ -64,7 +65,9 @@ public class StaticTableViewController: UITableViewController {
         case let .execute(block):
             block(cell,self)
         case let .open(url):
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            let safari = SFSafariViewController(url: url)
+            safari.dismissButtonStyle = .close
+            present(safari, animated: true, completion: nil)
         case let .present(viewController):
             present(viewController, animated: true, completion: nil)
         case let .push(viewController):

--- a/StaticTableView/StaticTableView.swift
+++ b/StaticTableView/StaticTableView.swift
@@ -68,7 +68,7 @@ public class StaticTableViewController: UITableViewController {
         case let .present(viewController):
             present(viewController, animated: true, completion: nil)
         case let .push(viewController):
-            navigationController?.pushViewController(viewController, animated: true)
+            navigationController!.pushViewController(viewController, animated: true)
         }
     }
 }

--- a/StaticTableView/StaticTableView.swift
+++ b/StaticTableView/StaticTableView.swift
@@ -58,6 +58,17 @@ public class StaticTableViewController: UITableViewController {
     override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         ///As a context, we pass the cell itself and the tableViewController (useful for navigation purposes)
         let cell = self.cell(for: indexPath)
-        cell.didSelect?(cell,self)
+        guard let handler = cell.selectionHandler else { return }
+        
+        switch handler {
+        case let .execute(block):
+            block(cell,self)
+        case let .open(url):
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        case let .present(viewController):
+            present(viewController, animated: true, completion: nil)
+        case let .push(viewController):
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 }

--- a/StaticTableView/Test.playground/Contents.swift
+++ b/StaticTableView/Test.playground/Contents.swift
@@ -15,15 +15,15 @@ let url = URL(string: "https://www.twitter.com/marcocapano1")!
 let staticTableView = StaticTableViewController(
     title: "Static TableView", sections: [
         Section(headerTitle: "Created by:", cells: [
-            StaticCell(text: "marcocapano", accessoryView: UIButton(type: .contactAdd), selectionHandler: .push(profile))
+            StaticCell(text: "marcocapano", accessoryView: UIButton(type: .contactAdd), whenSelected: .push(profile))
         ]),
         Section(headerTitle: "Details:", footerTitle: "Nice footer", cells: [
-            StaticCell(text: "Twitter @marcocapano1", selectionHandler: .open(url)),
+            StaticCell(text: "Twitter @marcocapano1", whenSelected: .open(url)),
             StaticCell(title: "Birth date", subtitle: "03/11/1997"),
             StaticCell(leftText: "Title", rightText: "iOS Developer"),
             StaticCell(text: "Curious", switchOn: true),
             StaticCell(text: "Cool README", accessoryType: .checkmark),
-            StaticCell(buttonTitle: "Add contact", selectionHandler: .present(add)),
+            StaticCell(buttonTitle: "Add contact", whenSelected: .present(add)),
             StaticCell(buttonTitle: "Block user", buttonColor: .red)
         ])
     ])

--- a/StaticTableView/Test.playground/Contents.swift
+++ b/StaticTableView/Test.playground/Contents.swift
@@ -2,29 +2,31 @@ import UIKit
 import PlaygroundSupport
 import StaticTableView
 
+let profile = UIViewController()
+profile.view.backgroundColor = .yellow
+profile.title = "marcocapano"
+
+let add = UIViewController()
+add.title = "Add contact"
+add.view.backgroundColor = .blue
+
+let url = URL(string: "https://www.twitter.com/marcocapano1")!
+
 let staticTableView = StaticTableViewController(
     title: "Static TableView", sections: [
         Section(headerTitle: "Created by:", cells: [
-            StaticCell(text: "marcocapano", accessoryView: UIButton(type: .contactAdd), whenSelected: { (cell, vc) in
-                let detail = UIViewController()
-                detail.view.backgroundColor = .yellow
-                detail.title = cell.textLabel?.text
-                vc.navigationController?.pushViewController(detail, animated: true)
-            })
+            StaticCell(text: "marcocapano", accessoryView: UIButton(type: .contactAdd), selectionHandler: .push(profile))
         ]),
         Section(headerTitle: "Details:", footerTitle: "Nice footer", cells: [
-            StaticCell(text: "Twitter @marcocapano1", whenSelected: { (_, vc) in
-                let url = URL(string: "www.twitter.com/marcocapano1")!
-                UIApplication.shared.open(url, options: [:])
-            }),
+            StaticCell(text: "Twitter @marcocapano1", selectionHandler: .open(url)),
             StaticCell(title: "Birth date", subtitle: "03/11/1997"),
             StaticCell(leftText: "Title", rightText: "iOS Developer"),
             StaticCell(text: "Curious", switchOn: true),
             StaticCell(text: "Cool README", accessoryType: .checkmark),
-            StaticCell(buttonTitle: "Add contact"),
+            StaticCell(buttonTitle: "Add contact", selectionHandler: .present(add)),
             StaticCell(buttonTitle: "Block user", buttonColor: .red)
         ])
     ])
 
-PlaygroundPage.current.liveView = UINavigationController(rootViewController: staticTableView)
+PlaygroundPage.current.liveView =  UINavigationController(rootViewController: staticTableView)
 

--- a/StaticTableViewTests/StaticTableViewTests.swift
+++ b/StaticTableViewTests/StaticTableViewTests.swift
@@ -59,7 +59,7 @@ class StaticTableViewTests: XCTestCase {
         let selection = expectation(description: "Waiting for cell selection")
         
         //Given
-        let cell = StaticCell(selectionHandler: .execute({ (_, _) in
+        let cell = StaticCell(whenSelected: .execute({ (_, _) in
             selection.fulfill()
         }), configure: { _ in })
         
@@ -71,14 +71,14 @@ class StaticTableViewTests: XCTestCase {
         //Test
         waitForExpectations(timeout: 2) { (error) in
             XCTAssertNil(error)
-            XCTAssertNotNil(cell.selectionHandler)
+            XCTAssertNotNil(cell.whenSelected)
         }
     }
     
     func testSelectionPresentVC() {
         //Given
         let presentedVC = UIViewController()
-        let cell = StaticCell(selectionHandler: .present(presentedVC), configure: { _ in })
+        let cell = StaticCell(whenSelected: .present(presentedVC), configure: { _ in })
         let tableViewController = StaticTableViewController(sections: [Section(cells: [cell])])
         
         let window = UIWindow()
@@ -90,7 +90,7 @@ class StaticTableViewTests: XCTestCase {
         tableViewController.tableView(tableViewController.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         
         //Test
-        XCTAssertNotNil(cell.selectionHandler)
+        XCTAssertNotNil(cell.whenSelected)
         XCTAssertEqual(tableViewController.presentedViewController, presentedVC)
         XCTAssertEqual(presentedVC.presentingViewController, tableViewController)
     }
@@ -98,7 +98,7 @@ class StaticTableViewTests: XCTestCase {
     func testSelectionPushVC() {
         //Given
         let pushedVC = UIViewController()
-        let cell = StaticCell(selectionHandler: .push(pushedVC), configure: { _ in })
+        let cell = StaticCell(whenSelected: .push(pushedVC), configure: { _ in })
         let tableViewController = StaticTableViewController(sections: [Section(cells: [cell])])
         let nav = UINavigationController(rootViewController: tableViewController)
         
@@ -111,7 +111,7 @@ class StaticTableViewTests: XCTestCase {
         tableViewController.tableView(tableViewController.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         
         //Test
-        XCTAssertNotNil(cell.selectionHandler)
+        XCTAssertNotNil(cell.whenSelected)
         XCTAssertEqual(nav.viewControllers.count, 2)
         XCTAssertEqual(nav.visibleViewController, pushedVC)
     }
@@ -119,7 +119,7 @@ class StaticTableViewTests: XCTestCase {
     func testSelectionOpenURL() {
         //Given
         let url = URL(string: "https://www.apple.com")!
-        let cell = StaticCell(selectionHandler: .open(url), configure: { _ in })
+        let cell = StaticCell(whenSelected: .open(url), configure: { _ in })
         let tableViewController = StaticTableViewController(sections: [Section(cells: [cell])])
         
         let window = UIWindow()
@@ -131,7 +131,7 @@ class StaticTableViewTests: XCTestCase {
         tableViewController.tableView(tableViewController.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         
         //Test
-        XCTAssertNotNil(cell.selectionHandler)
+        XCTAssertNotNil(cell.whenSelected)
         let visibleVC = tableViewController.presentedViewController as? SFSafariViewController
         XCTAssertNotNil(visibleVC)
     }

--- a/StaticTableViewTests/StaticTableViewTests.swift
+++ b/StaticTableViewTests/StaticTableViewTests.swift
@@ -56,13 +56,12 @@ class StaticTableViewTests: XCTestCase {
         let selection = expectation(description: "Waiting for cell selection")
         
         let vc = StaticTableViewController(sections: [])
-        let cell = StaticCell(didSelect: { (_,_) in
-            selection.fulfill()
-        }, configure: { _ in
-            //
-        })
         
-        XCTAssertNotNil(cell.didSelect)
+        let cell = StaticCell(selectionHandler: StaticCell.SelectionHandler.execute({ (_, _) in
+            selection.fulfill()
+        }), configure: { _ in })
+        
+        XCTAssertNotNil(cell.selectionHandler)
         cell.didSelect!(cell,vc)
         
         waitForExpectations(timeout: 2) { (error) in

--- a/StaticTableViewTests/StaticTableViewTests.swift
+++ b/StaticTableViewTests/StaticTableViewTests.swift
@@ -7,13 +7,15 @@
 //
 
 import XCTest
+import SafariServices
 @testable import StaticTableView
 
 class StaticTableViewTests: XCTestCase {
 
     func testEmptyTableView() {
+        //Given
         let staticTableView = StaticTableViewController(sections: [])
-        
+        //Test
         XCTAssertEqual(staticTableView.sections.count, 0)
     }
     
@@ -34,11 +36,12 @@ class StaticTableViewTests: XCTestCase {
     }
     
     func testConfigurationBlock() {
+        //Given
         let text = "Teeeext"
         let color = UIColor.green
         
         
-        //When cell is configured
+        //When
         let cell = StaticCell(style: .default) {
             $0.textLabel?.text = text
             $0.backgroundColor = color
@@ -46,7 +49,7 @@ class StaticTableViewTests: XCTestCase {
         
         cell.configure(cell)
         
-        //Test attributes
+        //Test
         XCTAssertNotNil(cell.configure)
         XCTAssertEqual(cell.textLabel?.text, text)
         XCTAssertEqual(cell.backgroundColor, color)
@@ -102,7 +105,7 @@ class StaticTableViewTests: XCTestCase {
         let window = UIWindow()
         window.rootViewController = nav
         window.addSubview(nav.view)
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 2))
+        RunLoop.current.run(until: Date())
         
         //When
         tableViewController.tableView(tableViewController.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
@@ -111,5 +114,25 @@ class StaticTableViewTests: XCTestCase {
         XCTAssertNotNil(cell.selectionHandler)
         XCTAssertEqual(nav.viewControllers.count, 2)
         XCTAssertEqual(nav.visibleViewController, pushedVC)
+    }
+    
+    func testSelectionOpenURL() {
+        //Given
+        let url = URL(string: "https://www.apple.com")!
+        let cell = StaticCell(selectionHandler: .open(url), configure: { _ in })
+        let tableViewController = StaticTableViewController(sections: [Section(cells: [cell])])
+        
+        let window = UIWindow()
+        window.rootViewController = tableViewController
+        window.addSubview(tableViewController.view)
+        RunLoop.current.run(until: Date())
+        
+        //When
+        tableViewController.tableView(tableViewController.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+        
+        //Test
+        XCTAssertNotNil(cell.selectionHandler)
+        let visibleVC = tableViewController.presentedViewController as? SFSafariViewController
+        XCTAssertNotNil(visibleVC)
     }
 }


### PR DESCRIPTION
This PR adds support for an enum-based selection handler.
The code looks basically the same when using the .execute(SelectionBlock) case but provides a way nicer API when presenting & pushing view controllers, and opening urls.

example:

``` swift
let aCell = StaticCell(text: "Cell", whenSelected: .present(vc))
let anotherCell = StaticCell(text: "Cell", whenSelected: .push(vc))
let cell = StaticCell(text: "Cell", whenSelected: .open(url))
```